### PR TITLE
Preventing a mysql error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3'
 services:
   db:
-    image: mysql
+    image: mysql:5.7
     ports:
       - "5432"
     environment:
       - MYSQL_DATABASE=SIGS_development
-      - MYSQL_ALLOW_EMPTY_PASSWORD='yes'
+      - MYSQL_ALLOW_EMPTY_PASSWORD='true'
 
   web:
     build: .


### PR DESCRIPTION
# Porposed Changes

The changes in this Pull Request were made with the intention to prevent an error that is related to the version 8.0 of MySQL: 

**500 Error Authentication plugin 'caching_sha2_password' cannot be loaded: /usr/lib/mysql/plugin/caching_sha2_password.so: cannot open shared object file: No such file or directory**

The proposed solution is to define a fixed  version of mysql image on the Docker Compose file.
For more info on how this solution came to be:
https://stackoverflow.com/questions/49979089/authentication-plugin-caching-sha2-password-cannot-be-loaded-in-circleci-mysql

# Type of Changes

- [ ] New backend feature or update.
- [ ] New frontend feature or update.
- [X] Bug fix.
- [ ] Another change (what was the change?).

# Checklist 
 
- [X] This Pull Request has a significant name.
- [X] The commits follow the [[commits policy]].
- [X] The build is okay (tests, code climate).
- [ ] This Pull Request mentions a related issue.
- [X] The change was necessary to the progress of the project.

