### PR TITLE
Removing useless shift validation to solicitate allocation

### DIFF
--- a/SIGS/app/models/room_solicitation.rb
+++ b/SIGS/app/models/room_solicitation.rb
@@ -20,15 +20,9 @@ class RoomSolicitation < ApplicationRecord
     errors.add(:start, error_mensager) if verify_time_shock_room_day
   end
 
-  def invalid_shift
-    shift = solicitation.school_room.courses[0].shift
-    (shift == 1 && final.strftime('%H').to_i > 18) ||
-      (shift == 2 && start.strftime('%H').to_i < 18)
-  end
-
   def time_invalid
     range = final.to_i - start.to_i
-    (range < 1) || invalid_shift
+    (range < 1)
   end
 
   def verify_time_shock_room_day


### PR DESCRIPTION
# Porposed Changes

Fixes https://github.com/MatheusRich/SIGS-GCES/issues/90.
The bug was caused by a previous update that allows the user to create an allocation solicitation outside of the course shift. One validation in the models prevented that from actually happening.

# Type of Changes

What type of change this Pull Request brings to SIGS? Put an **x** in the boxes that apply

- [ ] New backend feature or update.
- [ ] New frontend feature or update.
- [X] Bug fix.
- [ ] Another change (what was the change?).

# Checklist 

Put an **x** in the boxes that apply. If you're confused about any of the following topics, ask us. We're here to help you!
 
- [X] This Pull Request has a significant name.
- [X] The commits follow the [[commits policy]].
- [X] The build is okay (tests, code climate).
- [X] This Pull Request mentions a related issue.
- [X] The change was necessary to the progress of the project.

# Screenshots

![image](https://user-images.githubusercontent.com/15863005/42144130-e0628694-7d8f-11e8-969a-8172858dd974.png)